### PR TITLE
CON-378: Fixes found when writing documentation

### DIFF
--- a/examples/shapes/main.rs
+++ b/examples/shapes/main.rs
@@ -81,11 +81,11 @@ pub struct ShapeType {
     /// The color of the shape (used as the key field)
     pub color: String,
     /// The X coordinate of the shape
-    pub x: f64,
+    pub x: i64,
     /// The Y coordinate of the shape
-    pub y: f64,
+    pub y: i64,
     /// The size of the shape
-    pub shapesize: f64,
+    pub shapesize: i64,
 }
 
 /// Command-line arguments for the shapes example application

--- a/examples/shapes/publisher.rs
+++ b/examples/shapes/publisher.rs
@@ -87,13 +87,13 @@ pub fn main(
             TypedMode::Disabled => {
                 // Manual field setting when typed feature is disabled
                 instance
-                    .set_number("x", shape.x)
+                    .set_number("x", shape.x as f64)
                     .expect("Failed to set x coordinate");
                 instance
-                    .set_number("y", shape.y)
+                    .set_number("y", shape.y as f64)
                     .expect("Failed to set y coordinate");
                 instance
-                    .set_number("shapesize", shape.shapesize)
+                    .set_number("shapesize", shape.shapesize as f64)
                     .expect("Failed to set shapesize");
                 instance
                     .set_string("color", &shape.color)
@@ -122,9 +122,10 @@ fn compute_sample_for_id(sample_id: usize) -> super::ShapeType {
     const CENTER: (f64, f64) = (CANVAS.0 / 2.0, CANVAS.1 / 2.0);
     const INCREMENT: (f64, f64) = (CANVAS.0 / 5.0, CANVAS.1 / 5.0);
 
-    let x = CENTER.0 + f64::sin(sample_id as f64) * INCREMENT.0;
-    let y = CENTER.1 + f64::cos(sample_id as f64) * INCREMENT.1;
-    let shapesize = CANVAS.0 / 10.0 + f64::cos(sample_id as f64) * CANVAS.0 / 20.0;
+    let x = (CENTER.0 + f64::sin(sample_id as f64) * INCREMENT.0) as i64;
+    let y = (CENTER.1 + f64::cos(sample_id as f64) * INCREMENT.1) as i64;
+    let shapesize =
+        (CANVAS.0 / 10.0 + f64::cos(sample_id as f64) * CANVAS.0 / 20.0) as i64;
 
     super::ShapeType {
         color: COLOR.to_string(),

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -141,12 +141,10 @@ impl Connector {
                 "<Unknown RTI Connector for Rust version>".to_string(),
             ));
 
-        let version_string_to_return = format!(
+        format!(
             "RTI Connector for Rust, version {}\n{}\n{}",
             VERSION_STRING, ndds_build_id_string, rtiddsconnector_build_id_string
-        );
-        println!("{}", version_string_to_return);
-        version_string_to_return
+        )
     }
 
     /// Get the last error message from the underlying RTI Connector C API.


### PR DESCRIPTION
* The types used in `ShapeType` were not aligned with the underlying XML. This led to errors in `serialize`.
* The function `Connector::get_versions_string` printed the versions before returning the string.