### PR TITLE
CON-382: Feedback on FFI conventions

### DIFF
--- a/src/connector.rs
+++ b/src/connector.rs
@@ -9,7 +9,7 @@
 #![doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/docs/connector.md"))]
 
 use crate::{
-    ConnectorFallible, ConnectorResult, Input, Output, ffi::NativeConnector,
+    ConnectorFallible, ConnectorResult, Input, Output, ffi::FfiConnector,
     result::ErrorKind,
 };
 use std::{
@@ -99,7 +99,7 @@ pub struct Connector {
     name: String,
 
     /// The native connector instance, protected by a RwLock for thread-safe access.
-    native: RwLock<NativeConnector>,
+    native: RwLock<FfiConnector>,
 
     /// Thread-safe holders for Input entities.
     inputs: ThreadSafeEntityHolder<InputRecord>,
@@ -136,7 +136,7 @@ impl Connector {
         static VERSION_STRING: &str = env!("CARGO_PKG_VERSION");
 
         let (ndds_build_id_string, rtiddsconnector_build_id_string) =
-            NativeConnector::get_build_versions().unwrap_or((
+            FfiConnector::get_build_versions().unwrap_or((
                 "<Unknown RTI Connext version>".to_string(),
                 "<Unknown RTI Connector for Rust version>".to_string(),
             ));
@@ -149,7 +149,7 @@ impl Connector {
 
     /// Get the last error message from the underlying RTI Connector C API.
     pub(crate) fn get_last_error_message() -> Option<String> {
-        NativeConnector::get_last_error_message()
+        FfiConnector::get_last_error_message()
     }
 
     /// Create a new [`Connector`] from a named configuration contained
@@ -157,14 +157,14 @@ impl Connector {
     pub fn new(config_name: &str, config_file: &str) -> ConnectorResult<Connector> {
         static NATIVE_CONNECTOR_CREATION_LOCK: Mutex<()> = Mutex::new(());
 
-        let native: NativeConnector = {
+        let native: FfiConnector = {
             let _guard = NATIVE_CONNECTOR_CREATION_LOCK
                 .lock()
                 .inspect_err(|_| {
                     eprintln!("An error occurred while trying to lock the global native connector creation lock, continuing anyway...");
                 })
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
-            NativeConnector::new(config_name, config_file)?
+            FfiConnector::new(config_name, config_file)?
         };
 
         Ok(Connector {
@@ -257,7 +257,7 @@ impl Connector {
     /// Get immutable access to the [`NativeConnector`] (for read operations)
     pub(crate) fn native_ref(
         &self,
-    ) -> ConnectorResult<std::sync::RwLockReadGuard<'_, NativeConnector>> {
+    ) -> ConnectorResult<std::sync::RwLockReadGuard<'_, FfiConnector>> {
         self.native.read().map_err(|_| {
             ErrorKind::lock_poisoned_error(
                 "Another thread panicked while holding the native connector lock",
@@ -269,7 +269,7 @@ impl Connector {
     /// Get mutable access to the [`NativeConnector`] (for write operations)
     pub(crate) fn native_mut(
         &self,
-    ) -> ConnectorResult<std::sync::RwLockWriteGuard<'_, NativeConnector>> {
+    ) -> ConnectorResult<std::sync::RwLockWriteGuard<'_, FfiConnector>> {
         self.native.write().map_err(|_| {
             ErrorKind::lock_poisoned_error(
                 "Another thread panicked while holding the native connector lock",

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -254,7 +254,7 @@ impl Connector {
         self.outputs.release_entity(name)
     }
 
-    /// Get immutable access to the [`NativeConnector`] (for read operations)
+    /// Get immutable access to the [`FfiConnector`] (for read operations)
     pub(crate) fn native_ref(
         &self,
     ) -> ConnectorResult<std::sync::RwLockReadGuard<'_, FfiConnector>> {
@@ -266,7 +266,7 @@ impl Connector {
         })
     }
 
-    /// Get mutable access to the [`NativeConnector`] (for write operations)
+    /// Get mutable access to the [`FfiConnector`] (for write operations)
     pub(crate) fn native_mut(
         &self,
     ) -> ConnectorResult<std::sync::RwLockWriteGuard<'_, FfiConnector>> {

--- a/src/ffi/rtiddsconnector.rs
+++ b/src/ffi/rtiddsconnector.rs
@@ -8,7 +8,7 @@
 
 //! Everything related to the `rtiddsconnector` C API, including types, functions and helpers.
 
-use std::ffi;
+use std::{ffi, ptr::NonNull};
 
 // C representation of the ReturnCode enum.
 pub type NativeReturnCode = ffi::c_int;
@@ -79,16 +79,16 @@ impl ReturnCode {
 }
 
 #[repr(transparent)]
-pub struct ConnectorPtr(ffi::c_void);
+pub struct OpaqueConnector(ffi::c_void);
 
 #[repr(transparent)]
-pub struct DataWriterPtr(ffi::c_void);
+pub struct OpaqueDataWriter(ffi::c_void);
 
 #[repr(transparent)]
-pub struct DataReaderPtr(ffi::c_void);
+pub struct OpaqueDataReader(ffi::c_void);
 
 #[repr(transparent)]
-pub struct SamplePtr(ffi::c_void);
+pub struct OpaqueSample(ffi::c_void);
 
 pub trait NativeStringTrait {
     fn as_raw_ptr(&self) -> *const ffi::c_char;
@@ -203,118 +203,118 @@ unsafe extern "C" {
         config_name: *const std::ffi::c_char,
         config_file: *const std::ffi::c_char,
         options: *const ConnectorOptions,
-    ) -> *mut ConnectorPtr;
+    ) -> *mut OpaqueConnector;
 
-    pub unsafe fn RTI_Connector_delete(connector: *const ConnectorPtr);
+    pub unsafe fn RTI_Connector_delete(connector: *mut OpaqueConnector);
 
     pub unsafe fn RTI_Connector_get_datawriter(
-        connector: *const ConnectorPtr,
+        connector: NonNull<OpaqueConnector>,
         entity_name: *const std::ffi::c_char,
-    ) -> *mut DataWriterPtr;
+    ) -> *mut OpaqueDataWriter;
 
     pub unsafe fn RTI_Connector_get_datareader(
-        connector: *const ConnectorPtr,
+        connector: NonNull<OpaqueConnector>,
         entity_name: *const std::ffi::c_char,
-    ) -> *mut DataReaderPtr;
+    ) -> *mut OpaqueDataReader;
 
     pub unsafe fn RTI_Connector_get_native_sample(
-        connector: *const ConnectorPtr,
+        connector: NonNull<OpaqueConnector>,
         entity_name: *const std::ffi::c_char,
         index: ConnectorIndex,
-    ) -> *const SamplePtr;
+    ) -> *mut OpaqueSample;
 
     pub unsafe fn RTI_Connector_set_number_into_samples(
-        connector: *const ConnectorPtr,
+        connector: NonNull<OpaqueConnector>,
         entity_name: *const std::ffi::c_char,
         name: *const std::ffi::c_char,
         value: ffi::c_double,
     ) -> NativeReturnCode;
 
     pub unsafe fn RTI_Connector_set_boolean_into_samples(
-        connector: *const ConnectorPtr,
+        connector: NonNull<OpaqueConnector>,
         entity_name: *const std::ffi::c_char,
         name: *const std::ffi::c_char,
         value: ffi::c_int, // boolean
     ) -> NativeReturnCode;
 
     pub unsafe fn RTI_Connector_set_string_into_samples(
-        connector: *const ConnectorPtr,
+        connector: NonNull<OpaqueConnector>,
         entity_name: *const std::ffi::c_char,
         name: *const std::ffi::c_char,
         value: *const std::ffi::c_char,
     ) -> NativeReturnCode;
 
     pub unsafe fn RTI_Connector_clear_member(
-        connector: *const ConnectorPtr,
+        connector: NonNull<OpaqueConnector>,
         entity_name: *const std::ffi::c_char,
         name: *const std::ffi::c_char,
     ) -> NativeReturnCode;
 
     pub unsafe fn RTI_Connector_write(
-        connector: *const ConnectorPtr,
+        connector: NonNull<OpaqueConnector>,
         entity_name: *const std::ffi::c_char,
         params_json: *const std::ffi::c_char,
     ) -> NativeReturnCode;
 
     pub unsafe fn RTI_Connector_wait_for_matched_subscription(
-        writer: *const DataWriterPtr,
+        writer: NonNull<OpaqueDataWriter>,
         timeout: ffi::c_int,
         current_count_change: *mut ffi::c_int,
     ) -> NativeReturnCode;
 
     pub unsafe fn RTI_Connector_get_matched_subscriptions(
-        writer: *const DataWriterPtr,
+        writer: NonNull<OpaqueDataWriter>,
         json_str: *mut NativeAllocatedString,
     ) -> NativeReturnCode;
 
     pub unsafe fn RTI_Connector_wait_for_acknowledgments(
-        writer: *const DataWriterPtr,
+        writer: NonNull<OpaqueDataWriter>,
         timeout: ffi::c_int,
     ) -> NativeReturnCode;
 
     pub unsafe fn RTI_Connector_read(
-        connector: *const ConnectorPtr,
+        connector: NonNull<OpaqueConnector>,
         entity_name: *const std::ffi::c_char,
     ) -> NativeReturnCode;
 
     pub unsafe fn RTI_Connector_take(
-        connector: *const ConnectorPtr,
+        connector: NonNull<OpaqueConnector>,
         entity_name: *const std::ffi::c_char,
     ) -> NativeReturnCode;
 
     pub unsafe fn RTI_Connector_return_loan(
-        connector: *const ConnectorPtr,
+        connector: NonNull<OpaqueConnector>,
         entity_name: *const std::ffi::c_char,
     ) -> NativeReturnCode;
 
     pub unsafe fn RTI_Connector_wait_for_data(
-        connector: *const ConnectorPtr,
+        connector: NonNull<OpaqueConnector>,
         timeout: ffi::c_int,
     ) -> NativeReturnCode;
 
     pub unsafe fn RTI_Connector_wait_for_data_on_reader(
-        reader: *const DataReaderPtr,
+        reader: NonNull<OpaqueDataReader>,
         timeout: ffi::c_int,
     ) -> NativeReturnCode;
 
     pub unsafe fn RTI_Connector_wait_for_matched_publication(
-        reader: *const DataReaderPtr,
+        reader: NonNull<OpaqueDataReader>,
         timeout: ffi::c_int,
         current_count_change: *mut ffi::c_int,
     ) -> NativeReturnCode;
 
     pub unsafe fn RTI_Connector_get_matched_publications(
-        reader: *const DataReaderPtr,
+        reader: NonNull<OpaqueDataReader>,
         json_str: *mut NativeAllocatedString,
     ) -> NativeReturnCode;
 
     pub unsafe fn RTI_Connector_clear(
-        connector: *const ConnectorPtr,
+        connector: NonNull<OpaqueConnector>,
         entity_name: *const std::ffi::c_char,
     ) -> NativeReturnCode;
 
     pub unsafe fn RTI_Connector_get_boolean_from_infos(
-        connector: *const ConnectorPtr,
+        connector: NonNull<OpaqueConnector>,
         return_value: *mut ffi::c_int, // boolean
         entity_name: *const std::ffi::c_char,
         index: ConnectorIndex,
@@ -322,7 +322,7 @@ unsafe extern "C" {
     ) -> NativeReturnCode;
 
     pub unsafe fn RTI_Connector_get_json_from_infos(
-        connector: *const ConnectorPtr,
+        connector: NonNull<OpaqueConnector>,
         entity_name: *const std::ffi::c_char,
         index: ConnectorIndex,
         name: *const std::ffi::c_char,
@@ -330,13 +330,13 @@ unsafe extern "C" {
     ) -> NativeReturnCode;
 
     pub unsafe fn RTI_Connector_get_sample_count(
-        connector: *const ConnectorPtr,
+        connector: NonNull<OpaqueConnector>,
         entity_name: *const std::ffi::c_char,
         out_value: *mut ffi::c_double,
     ) -> NativeReturnCode;
 
     pub unsafe fn RTI_Connector_get_number_from_sample(
-        connector: *const ConnectorPtr,
+        connector: NonNull<OpaqueConnector>,
         return_value: *mut ffi::c_double,
         entity_name: *const std::ffi::c_char,
         index: ConnectorIndex,
@@ -344,7 +344,7 @@ unsafe extern "C" {
     ) -> NativeReturnCode;
 
     pub unsafe fn RTI_Connector_get_boolean_from_sample(
-        connector: *const ConnectorPtr,
+        connector: NonNull<OpaqueConnector>,
         return_value: *mut ffi::c_int, // boolean
         entity_name: *const std::ffi::c_char,
         index: ConnectorIndex,
@@ -352,7 +352,7 @@ unsafe extern "C" {
     ) -> NativeReturnCode;
 
     pub unsafe fn RTI_Connector_get_string_from_sample(
-        connector: *const ConnectorPtr,
+        connector: NonNull<OpaqueConnector>,
         return_value: *mut NativeAllocatedString,
         entity_name: *const std::ffi::c_char,
         index: ConnectorIndex,
@@ -360,7 +360,7 @@ unsafe extern "C" {
     ) -> NativeReturnCode;
 
     pub unsafe fn RTI_Connector_get_any_from_sample(
-        connector: *const ConnectorPtr,
+        connector: NonNull<OpaqueConnector>,
         double_value_out: *mut ffi::c_double,
         bool_value_out: *mut ffi::c_int, // boolean
         string_value_out: *mut NativeAllocatedString,
@@ -371,7 +371,7 @@ unsafe extern "C" {
     ) -> NativeReturnCode;
 
     pub unsafe fn RTI_Connector_get_any_from_info(
-        connector: *const ConnectorPtr,
+        connector: NonNull<OpaqueConnector>,
         double_value_out: *mut ffi::c_double,
         bool_value_out: *mut ffi::c_int, // boolean
         string_value_out: *mut NativeAllocatedString,
@@ -382,14 +382,14 @@ unsafe extern "C" {
     ) -> NativeReturnCode;
 
     pub unsafe fn RTI_Connector_get_json_sample(
-        connector: *const ConnectorPtr,
+        connector: NonNull<OpaqueConnector>,
         entity_name: *const std::ffi::c_char,
         index: ConnectorIndex,
         json_str: *mut NativeAllocatedString,
     ) -> NativeReturnCode;
 
     pub unsafe fn RTI_Connector_get_json_member(
-        connector: *const ConnectorPtr,
+        connector: NonNull<OpaqueConnector>,
         entity_name: *const std::ffi::c_char,
         index: ConnectorIndex,
         member_name: *const std::ffi::c_char,
@@ -397,7 +397,7 @@ unsafe extern "C" {
     ) -> NativeReturnCode;
 
     pub unsafe fn RTI_Connector_set_json_instance(
-        connector: *const ConnectorPtr,
+        connector: NonNull<OpaqueConnector>,
         entity_name: *const std::ffi::c_char,
         json: *const std::ffi::c_char,
     ) -> NativeReturnCode;
@@ -406,13 +406,13 @@ unsafe extern "C" {
 
     #[allow(unused)]
     pub unsafe fn RTI_Connector_get_native_instance(
-        connector: *const ConnectorPtr,
+        connector: NonNull<OpaqueConnector>,
         entity_name: *const std::ffi::c_char,
-        native_pointer: *mut *const SamplePtr,
+        native_pointer: *mut *const OpaqueSample,
     ) -> NativeReturnCode;
 
     pub unsafe fn RTIDDSConnector_getJSONInstance(
-        connector: *const ConnectorPtr,
+        connector: NonNull<OpaqueConnector>,
         entity_name: *const std::ffi::c_char,
     ) -> NativeAllocatedString;
 


### PR DESCRIPTION
There are some idioms in Rust more suitable for our code, such as using `std::ptr::NonNull`.
We should prefer these to enforce a safer and cleaner code.

* `Native{}` now holds a `NonNull<T>` instead of a `*const T`.
* FFI calls that take a pointer "self" argument prefer `NonNull<T>`, because the C API expects non-null and `NonNull<T>` is transparent over `*const T`.

Additionally, we could use the chance to revisit the naming conventions on FFI-related types to better reflect their nature.

* `Native{}` --> `Ffi{}`: "Native" could refer to anything, but FFI implies "glue".
* `{}Ptr` --> `Opaque{}`: The types were never pointers to begin with.